### PR TITLE
Update RemoveWindowsAi.ps1

### DIFF
--- a/RemoveWindowsAi.ps1
+++ b/RemoveWindowsAi.ps1
@@ -360,7 +360,12 @@ function Disable-Registry-Keys {
     }
     if (!$revert) {
         #remove conversational agent service (used to be used for cortana, prob going to be updated for new ai agents and copilot)
-        $aarSVCName = (Get-Service -ErrorAction SilentlyContinue | Where-Object { $_.name -like '*aarsvc*' }).Name
+        try {
+            $aarSVCName = (Get-CimInstance -ClassName Win32_Service -Filter "Name LIKE '%aarsvc%'" -ErrorAction SilentlyContinue).Name
+        }
+        catch {
+            $aarSVCName = $null
+        }
 
         if ($aarSVCName) {
             if ($backup) {
@@ -2347,5 +2352,6 @@ if (!$nonInteractive) {
     Write-Host 'Done! Press Any Key to Exit...' -ForegroundColor Green
     $Host.UI.RawUI.ReadKey() *>$null
 }
+
 
 exit


### PR DESCRIPTION
Full Disclosure: AI was used to find a different way, I'm a shell noob (The irony lmao)

The root cause is admin rights on "PrintScanBrokerService" are not enough for this operation. It fails despite aarsvc being present. So just skipping it would be wrong IMO. The new way makes it work for me. 