### PR TITLE
Fix UWP settings lock retries and AI package file cleanup in `RemoveWindowsAi.ps1`

### DIFF
--- a/RemoveWindowsAi.ps1
+++ b/RemoveWindowsAi.ps1
@@ -604,6 +604,7 @@ function Set-UwpAppRegistryEntry {
 
         # since we are trying multiple times while the processes are stopping this will work as soon as the file is freed 
         do {
+            Start-Sleep -Milliseconds 200
             reg.exe LOAD $AppSettingsRegPath $FilePath *>$null
             $attempts++
         } while ($LASTEXITCODE -ne 0 -and $attempts -lt $max)

--- a/RemoveWindowsAi.ps1
+++ b/RemoveWindowsAi.ps1
@@ -2743,7 +2743,7 @@ function Remove-AI-Files {
         $jobs = foreach ($path in $paths) {
             $rs = [powershell]::Create().AddScript({
                     param($path)
-                    (Get-ChildItem -Path $path -Directory -Force -ErrorAction SilentlyContinue | 
+                    (Get-ChildItem -Path $path -Force -ErrorAction SilentlyContinue | 
                     Where-Object { $_.FullName -like '*UserExperience-AIX*' -or 
                         $_.FullName -like '*Copilot*' -or 
                         $_.FullName -like '*UserExperience-Recall*' -or 

--- a/RemoveWindowsAi.ps1
+++ b/RemoveWindowsAi.ps1
@@ -3122,7 +3122,8 @@ function Remove-AI-Files {
         $jobs = foreach ($dir in $dirs) {
             $rs = [powershell]::Create().AddScript({
                     param($dir, $aiKeyWords)
-                    (Get-ChildItem $dir -Recurse -Directory -ErrorAction SilentlyContinue | Where-Object { 
+                    if ($dir -match 'WinSxS') { $items = Get-ChildItem $dir -Recurse -Directory -ErrorAction SilentlyContinue } else { $items = Get-ChildItem $dir -Recurse -File -ErrorAction SilentlyContinue }
+                    ($items | Where-Object { 
                         $_.FullName -like "*$($aiKeyWords[0])*" -or 
                         $_.FullName -like "*$($aiKeyWords[1])*" -or 
                         $_.FullName -like "*$($aiKeyWords[2])*" -or


### PR DESCRIPTION
Addresses issues with UWP registry setting locks and incomplete AI package file removal:

- **Fix `settings.dat` registry lock retries**: Added a 200ms delay inside the `reg.exe LOAD` retry loop. Previously, it would exhaust all 30 attempts in milliseconds before stopped UWP processes could release their file handles.
- **Fix CBS package file removal**: Removed the `-Directory` restriction when checking shallow package paths (`servicing\Packages` and `CatRoot`) so `.mum` and `.cat` files are matched and removed.
- **Optimize recursive file cleanup**: Updated the deep recursive scan to differentiate between target paths—using `-Directory` for `WinSxS` to prevent scanning 100,000+ individual files, and `-File` for `CatRoot` to properly capture `.cat` catalog files.