### PR TITLE
Fix PreventAIPackageReinstall option not working in nonInteractive mode

### DIFF
--- a/RemoveWindowsAi.ps1
+++ b/RemoveWindowsAi.ps1
@@ -3930,7 +3930,7 @@ if ($nonInteractive) {
     else {
         $allFunctions = @(
             'DisableRegKeys' 
-            'Prevent-AI-Package-Reinstall' 
+            'PreventAIPackageReinstall' 
             'DisableCopilotPolicies' 
             'RemoveAppxPackages' 
             'RemoveRecallFeature' 
@@ -3952,7 +3952,7 @@ if ($nonInteractive) {
         #loop through options array and run desired tweaks
         switch ($activeOptions) {
             'DisableRegKeys' { Disable-Registry-Keys }
-            'Prevent-AI-Package-Reinstall' { Install-NOAIPackage }
+            'PreventAIPackageReinstall' { Install-NOAIPackage }
             'DisableCopilotPolicies' { Disable-Copilot-Policies }
             'RemoveAppxPackages' { Remove-AI-Appx-Packages }
             'RemoveRecallFeature' { Remove-Recall-Optional-Feature }


### PR DESCRIPTION
## Bug

When running the script non-interactively with `-Options PreventAIPackageReinstall`, `Install-NOAIPackage` is never executed — the script completes silently with no error and no indication that anything was skipped.

## Root Cause

The `-Options` parameter's `ValidateSet` (line 5) only accepts the value `PreventAIPackageReinstall` (no dashes). However, in the non-interactive handling block, both the option list and the corresponding switch case use a different, dashed spelling:

- Line 3933: `'Prevent-AI-Package-Reinstall'` in the `$allFunctions` array
- Line 3955: `'Prevent-AI-Package-Reinstall'` as the switch case

Since `$Options` can only ever contain the no-dash form (enforced by `ValidateSet`), it never matches the dashed string used in the switch, so the corresponding case is unreachable. This also means the option is unaffected by `-ExcludeOptions`, since the exclusion filter compares against the same mismatched string.

Every other entry in both lists uses the no-dash form consistently and matches `ValidateSet` correctly.

## Fix

Changed `'Prevent-AI-Package-Reinstall'` to `'PreventAIPackageReinstall'` on lines 3933 and 3955 to match the `ValidateSet` declaration.

## Testing

Ran the unmodified script and the patched script with:

    powershell.exe -ExecutionPolicy Bypass -File .\RemoveWindowsAi.ps1 -nonInteractive -Options PreventAIPackageReinstall

**Before fix:** script prints the banner and exits with no further output — `Install-NOAIPackage` is never invoked.
<img width="1008" height="87" alt="Screenshot 2026-08-08 221145" src="https://github.com/user-attachments/assets/0104cfb9-ef77-4ca2-b9dc-d8887d39c7b4" />

**After fix:** script correctly proceeds to run `Install-NOAIPackage`.
<img width="1002" height="147" alt="Screenshot 2026-08-08 221838" src="https://github.com/user-attachments/assets/33a8587c-a316-4ae6-89c5-3a870062bb49" />

> [!Note] 
>The interactive GUI is unaffected, as it uses a separate, self-consistent dashed naming scheme (`$functions` array around line 4118 and its own switch at line 4879) that isn't tied to this `ValidateSet`.